### PR TITLE
Fix for missing logger default

### DIFF
--- a/DomsUtils/Services/Caching/Hybrids/DirectionalTierCache/DirectionalTierCache.cs
+++ b/DomsUtils/Services/Caching/Hybrids/DirectionalTierCache/DirectionalTierCache.cs
@@ -50,7 +50,7 @@ public sealed class DirectionalTierCache<TKey, TValue> : ICache<TKey, TValue>, I
         _tiers = new List<ICache<TKey, TValue>>(tiers).ToArray();
         _cacheDirection = cacheDirection;
         _migrationStrategy = migrationStrategy;
-        _logger = logger;
+        _logger = logger ?? NullLogger.Instance;
 
         _logger.LogInformation("DirectionalTierCache initialized with {TierCount} tiers.", _tiers.Length);
 


### PR DESCRIPTION
## Summary
- fix potential NRE in DirectionalTierCache constructor

## Testing
- `dotnet test --no-build --filter FullyQualifiedName~DirectionalTierCache --logger:"console;verbosity=quiet"`
- `dotnet test --no-build --filter FullyQualifiedName~FileCacheTest.IsAvailable_WithReadOnlyDirectory_ReturnsFalse --logger:"console;verbosity=quiet"` *(fails: Assert.IsFalse)*

------
https://chatgpt.com/codex/tasks/task_e_6842dab3edf48320a4b3c884983750e6