### PR TITLE
Refine README landing page

### DIFF
--- a/DomsUtils/DataStructures/BiMap/README.md
+++ b/DomsUtils/DataStructures/BiMap/README.md
@@ -1,0 +1,40 @@
+# BiMap Utilities
+
+This folder contains the bidirectional dictionary implementation and related helpers.
+
+## Classes
+
+- `BiMap<TKey,TValue>` – core bidirectional map enforcing one-to-one mapping. Key functions:
+  - `Add(key, value)` / `AddRange(items)`
+  - `RemoveByKey(key)` / `RemoveByValue(value)`
+  - `TryAdd(key, value)` and async counterparts
+  - `TryGetByKey(key, out value)` / `TryGetByValue(value, out key)`
+  - Span helpers like `TryGetKeysToSpan` for high performance
+- `ObservableBiMap<TKey,TValue>` – raises `CollectionChanged` and `PropertyChanged` events when the map changes.
+- `BiMapExtensions` – convert dictionaries or enumerables into a `BiMap`.
+- `BiMapJsonExtensions` – serialize and deserialize a map through `System.Text.Json`.
+
+## Example
+
+```csharp
+using DomsUtils.DataStructures.BiMap.Base;
+using DomsUtils.DataStructures.BiMap.Extensions;
+
+// create map
+var map = new BiMap<int, string>();
+map.Add(1, "one");
+map.AddRange(new[]{ new KeyValuePair<int,string>(2,"two") });
+
+// lookup
+if (map.TryGetByKey(1, out var value))
+    Console.WriteLine(value); // "one"
+
+// convert from dictionary
+var dict = new Dictionary<int,string>{{3,"three"}};
+BiMap<int,string> fromDict = dict.ToBiMap();
+
+// JSON round trip
+string json = fromDict.Serialize();
+BiMap<int,string>? restored = BiMapJsonExtensions.Deserialize<int,string>(json);
+```
+

--- a/DomsUtils/DataStructures/CircularBuffer/Base/README.md
+++ b/DomsUtils/DataStructures/CircularBuffer/Base/README.md
@@ -1,0 +1,30 @@
+# CircularBuffer
+
+A fixed-size circular buffer optimized for constant time enqueue and dequeue operations.
+
+## Key Members
+
+- `TryEnqueue(item)` – attempts to add an item if space is available.
+- `EnqueueOverwrite(item)` – adds an item, overwriting the oldest when full.
+- `TryDequeue(out item)` – removes the oldest element.
+- `TryPeek(out item)` – reads the next element without removing it.
+- `Clear(bool zeroMemory)` – resets the buffer.
+- `GetEnumerator()` – allocation-free enumerator over contents.
+
+## Example
+
+```csharp
+using DomsUtils.DataStructures.CircularBuffer.Base;
+
+var buffer = new CircularBuffer<int>(8);
+
+buffer.TryEnqueue(1);
+buffer.EnqueueOverwrite(2);
+
+if (buffer.TryPeek(out int head))
+    Console.WriteLine($"next: {head}");
+
+while (buffer.TryDequeue(out int value))
+    Console.WriteLine(value);
+```
+

--- a/DomsUtils/Services/Caching/Bases/README.md
+++ b/DomsUtils/Services/Caching/Bases/README.md
@@ -1,0 +1,32 @@
+# Base Caches
+
+Implementations that store data in specific mediums.
+
+## FileCache<TKey,TValue>
+
+Stores values as JSON files on disk.
+- `TryGet(key, out value)`
+- `Set(key, value)`
+- `Remove(key)` and `Clear()`
+
+## MemoryCache<TKey,TValue>
+
+Thread safe in-memory dictionary with events.
+- `TryGet`, `Set`, `Remove`, `Clear`
+- `OnSet` event fires when values are updated.
+
+## S3Cache<TKey,TValue>
+
+Persists entries in an Amazon S3 bucket.
+- `TryGet`, `Set`, `Remove`, `Clear`
+- factory `Create` helpers for custom key converters.
+
+### Example
+
+```csharp
+var cache = new MemoryCache<string,int>();
+cache.Set("count", 5);
+if (cache.TryGet("count", out int c))
+    Console.WriteLine(c);
+```
+

--- a/DomsUtils/Services/Caching/Hybrids/README.md
+++ b/DomsUtils/Services/Caching/Hybrids/README.md
@@ -1,0 +1,30 @@
+# Hybrid Caches
+
+Compositions built from multiple underlying caches.
+
+## TieredCache<TKey,TValue>
+
+Uses several caches in priority order and can migrate entries between tiers.
+- `TryGet`, `Set`, `Remove`, `Clear`
+- `TriggerMigrationNow()` forces migration according to rules.
+
+## DirectionalTierCache<TKey,TValue>
+
+Directional migration between tiers based on strategy and cache ordering.
+
+## ParallelCache<TKey,TValue>
+
+Writes to all caches in parallel and reads in priority order.
+
+### Example
+
+```csharp
+var mem = new MemoryCache<string,int>();
+var file = new FileCache<string,int>("./cache");
+var tiered = new TieredCache<string,int>(new MigrationRuleSet<string,int>(), mem, file);
+
+tiered.Set("a", 1);
+if (tiered.TryGet("a", out int v))
+    Console.WriteLine(v);
+```
+

--- a/DomsUtils/Services/Caching/README.md
+++ b/DomsUtils/Services/Caching/README.md
@@ -1,0 +1,22 @@
+# Caching Services
+
+This directory provides cache implementations and combinators.
+
+## Subfolders
+
+- [Bases](Bases/README.md) – file, memory and S3 based caches.
+- [Hybrids](Hybrids/README.md) – multi-cache combinations like tiered and parallel caches.
+- `Interfaces` – common contracts for caches and addons.
+- `Addons` – migration rule helpers.
+
+## Basic Usage
+
+```csharp
+using DomsUtils.Services.Caching.Bases;
+
+ICache<string,int> cache = new MemoryCache<string,int>();
+cache.Set("a", 1);
+if (cache.TryGet("a", out int v))
+    Console.WriteLine(v);
+```
+

--- a/DomsUtils/Services/Pipeline/README.md
+++ b/DomsUtils/Services/Pipeline/README.md
@@ -1,0 +1,27 @@
+# ChannelPipeline
+
+A composable channel-based pipeline for asynchronous data processing.
+
+## Building Blocks
+
+- `ChannelPipeline<T>` – orchestrates processing blocks.
+- `BlockOptions<T>` – configure transformations and parallelism.
+- `BlockModifier<T>` – delegate to wrap transformations with extra behavior.
+- `Envelope<T>` – wrapper that tracks item ordering.
+
+## Example
+
+```csharp
+using DomsUtils.Services.Pipeline;
+
+var pipeline = new ChannelPipeline<int>(preserveOrder: true)
+    .AddBlock(new BlockOptions<int>
+    {
+        AsyncTransform = async (v, ct) => v * 2,
+        Parallelism = 2
+    });
+
+await pipeline.WriteAsync(5, CancellationToken.None);
+await pipeline.DisposeAsync();
+```
+

--- a/DomsUtils/Tooling/Async/README.md
+++ b/DomsUtils/Tooling/Async/README.md
@@ -1,0 +1,26 @@
+# AsyncUtils
+
+Utility helpers for running synchronous and asynchronous delegates.
+
+## Functions
+
+- `RunSync(Action)` and `RunSync(Func<T>)` – execute immediately.
+- `RunAsync(Func<Task>)` / `RunAsync(Func<Task<T>>)` – run on the thread pool.
+- `FireAndForget(Func<Task>, onError)` – background run with optional error handler.
+- `WithTimeout(task, timeout)` – enforce a timeout.
+- `RetryAsync(operation, maxRetries)` – retry with exponential backoff.
+
+## Example
+
+```csharp
+using DomsUtils.Tooling.Async;
+
+await (() => Task.Delay(100)).RunAsync();
+
+AsyncUtils.FireAndForget(async () =>
+{
+    await Task.Delay(50);
+    Console.WriteLine("done");
+});
+```
+

--- a/DomsUtils/Tooling/ExtensionMethods/README.md
+++ b/DomsUtils/Tooling/ExtensionMethods/README.md
@@ -1,0 +1,22 @@
+# EnumerableExtensions
+
+Convenience methods for working with `IEnumerable<T>`.
+
+## Functions
+
+- `IsNullOrEmpty()` / `HasItems()` – quick null and count checks.
+- `ForEach(action)` – iterate with an action delegate.
+- `WhereNotNull()` – filter out nulls.
+- `FirstOrDefaultSafe()` / `LastOrDefaultSafe()` – efficient boundary retrieval.
+- `ToHashSetSafe()` – convert to `HashSet` even if source is null.
+- `DistinctSafe()` – distinct elements with null safety.
+
+## Example
+
+```csharp
+using DomsUtils.Tooling.ExtensionMethods;
+
+var items = new[] { 1, 2, 2, 3 };
+items.DistinctSafe().ForEach(Console.WriteLine);
+```
+

--- a/README.md
+++ b/README.md
@@ -1,196 +1,50 @@
 # DomsUtils
 
-A collection of .NET utility classes providing bidirectional dictionaries, observable variants, extension methods, and JSON serialization support—features not commonly found in standard libraries.
+A growing collection of general‑purpose utilities for .NET projects. The library bundles data structures, caching helpers and small tooling components so they can be reused across applications.
 
-## Table of Contents
+## Modules
 
-- [Features](#features)  
-- [Installation](#installation)  
-- [Usage](#usage)  
-  - [BiMap](#bimap)  
-  - [ObservableBiMap](#observablebimap)  
-  - [Extension Methods](#extension-methods)  
-  - [JSON Serialization](#json-serialization)  
-- [API Reference](#api-reference)  
-- [Testing](#testing)  
-- [Contributing](#contributing)  
-- [License](#license)  
+- **[BiMap](DomsUtils/DataStructures/BiMap/README.md)** – bidirectional dictionary implementation.
+- **[CircularBuffer](DomsUtils/DataStructures/CircularBuffer/Base/README.md)** – fixed size queue with constant time operations.
+- **[Caching](DomsUtils/Services/Caching/README.md)** – memory, file and S3 based caches with hybrid compositions.
+- **[Pipeline](DomsUtils/Services/Pipeline/README.md)** – composable channel pipeline for async workloads.
+- **[Async Utils](DomsUtils/Tooling/Async/README.md)** – helpers for running delegates with retries and timeouts.
+- **[Enumerable Extensions](DomsUtils/Tooling/ExtensionMethods/README.md)** – LINQ style helpers for `IEnumerable<T>`.
 
-## Features
+## Getting Started
 
-- **BiMap\<TKey, TValue\>**  
-  A bidirectional map enforcing a one-to-one correspondence between keys and values.  
-- **ObservableBiMap\<TKey, TValue\>**  
-  Extends `BiMap` with `INotifyCollectionChanged` and `INotifyPropertyChanged` for real-time change notifications.  
-- **Extension Methods**  
-  - `IDictionary<TKey,TValue>.ToBiMap()` for direct conversion.  
-  - `ToBiMapSafe()` overloads with conflict-resolution callbacks.  
-  - `IEnumerable<T>.ToBiMap()` overloads mapping sequences to bi-maps.  
-- **JSON Support**  
-  - `BiMapJsonExtensions.Serialize()` / `.Deserialize()` for easy JSON round-trip.  
-  - Custom `JsonConverterFactory`/`JsonConverter` preserving bijectivity.
+Requires **.NET 9** or later.
 
-## Installation
+```bash
+# clone and build
+git clone https://gitea.essenhofer.at/DomDom3333/DomsUtils.git
+cd DomsUtils
+ dotnet build
+```
 
-Requires **.NET 9.0** or later.
+Add a project reference to `DomsUtils/DomsUtils.csproj` or copy the built DLL to your project.
 
-1. **Clone & build**  
-   ```bash
-   git clone https://gitea.essenhofer.at/DomDom3333/DomsUtils.git
-   cd DomsUtils
-   dotnet build
+## Example
 
-2. **Reference**
-
-    * Add a project reference to `DomsUtils/DomsUtils.csproj`, or
-    * Copy the compiled `DomsUtils.dll` into your project.
-
-## Usage
-
-### BiMap
+A simple use of the bidirectional map:
 
 ```csharp
 using DomsUtils.Classes.BiMap.Base;
 
-// Create and populate
-var biMap = new BiMap<int, string>();
-biMap.Add(1, "One");
-biMap.Add(2, "Two");
-
-// Lookup by key
-Console.WriteLine(biMap[1]);      // "One"
-
-// Lookup by value
-Console.WriteLine(biMap["Two"]);  // 2
-
-// Safe add
-if (!biMap.TryAdd(2, "Second"))
-    Console.WriteLine("Duplicate key or value");
-
-// Remove entries
-biMap.RemoveByKey(1);
-biMap.RemoveByValue("Two");
+var map = new BiMap<int, string>();
+map.Add(1, "One");
+map.Add(2, "Two");
+Console.WriteLine(map["Two"]); // prints 2
 ```
 
-Key members:
-
-| Member                   | Description                                           |
-| ------------------------ | ----------------------------------------------------- |
-| `Count`                  | Number of entries                                     |
-| `Keys`, `Values`         | Enumerables of all keys or values                     |
-| `ContainsKey(key)`       | Tests for existence of a key                          |
-| `ContainsValue(value)`   | Tests for existence of a value                        |
-| `TryGetByKey/Value(...)` | Try-pattern lookup without exceptions                 |
-| `Clear()`                | Removes all entries                                   |
-| Indexers (`this[key]`)   | Throws `KeyNotFoundException` on missing key or value |
-
-### ObservableBiMap
-
-```csharp
-using DomsUtils.Classes.BiMap.Children.Observable;
-using System.Collections.Specialized;
-using System.ComponentModel;
-
-var obsMap = new ObservableBiMap<string, int>();
-
-obsMap.CollectionChanged += (s, e) =>
-    Console.WriteLine($"Collection changed: {e.Action}");
-
-obsMap.PropertyChanged += (s, e) =>
-    Console.WriteLine($"Property {e.PropertyName} changed");
-
-// Triggers notifications
-obsMap.Add("A", 1);
-obsMap.RemoveByKey("A");
-```
-
-Supports all `BiMap` operations plus:
-
-* **INotifyCollectionChanged**
-* **INotifyPropertyChanged**
-
-### Extension Methods
-
-Convert standard collections into `BiMap`:
-
-```csharp
-using DomsUtils.Classes.BiMap.Extensions;
-
-// Dictionary → BiMap
-var dict = new Dictionary<int,string>{{1,"One"},{2,"Two"}};
-var map1 = dict.ToBiMap();
-
-// Safe conversion with conflict resolver
-var map2 = dict.ToBiMapSafe((key, val) => {
-    // Return true to overwrite existing entry
-    return key % 2 == 0;
-});
-
-// Enumerable → BiMap via selectors
-var words = new[] { "alpha", "beta", "gamma" };
-var map3 = words.ToBiMap(
-    word => word,         // key selector
-    word => word.Length); // value selector
-```
-
-### JSON Serialization
-
-Leverage built-in JSON support:
-
-```csharp
-using System.Text.Json;
-using DomsUtils.Classes.BiMap.Extensions;
-
-var biMap = new BiMap<int,string> { {1,"One"}, {2,"Two"} };
-
-// Serialize to JSON
-string json = biMap.Serialize(new JsonSerializerOptions { WriteIndented = true });
-Console.WriteLine(json);
-
-// Deserialize back
-var restored = BiMapJsonExtensions.Deserialize<int,string>(json);
-```
-
-Under the hood, a custom `JsonConverterFactory` ensures no duplicate values are introduced during deserialization.
-
-## API Reference
-
-* **Namespace**: `DomsUtils.Classes.BiMap.Base`
-
-    * `BiMap<TKey,TValue>`
-    * `IBiMap<TKey,TValue>`
-* **Namespace**: `DomsUtils.Classes.BiMap.Children.Observable`
-
-    * `ObservableBiMap<TKey,TValue>`
-* **Namespace**: `DomsUtils.Classes.BiMap.Extensions`
-
-    * `BiMapExtensions`
-    * `BiMapJsonExtensions`
-* **Namespace**: `DomsUtils.Classes.BiMap.Base.Tooling`
-
-    * `BiMapJsonConverterFactory`
-    * `BiMapJsonConverter<TKey,TValue>`
-
-> For detailed API signatures and XML docs, consult the source code or generate documentation with your preferred tool.
+See the module guides linked above for more details and samples.
 
 ## Testing
 
-Unit tests cover construction, add/remove operations, lookups, enumeration, custom comparers, async operations, and JSON round-trip.
+Run the unit tests from the solution root:
 
 ```bash
-cd DomsUtils.Tests
-dotnet test
+ dotnet test -v q
 ```
-
-## Contributing
-
-Contributions are welcome!
-
-1. Fork the repository.
-2. Create a feature branch.
-3. Add tests for new functionality.
-4. Submit a pull request.
-
-Please adhere to the existing coding style and include XML doc comments for any new public members.
 
 ## [License](License.md)


### PR DESCRIPTION
## Summary
- condense root README into a landing page
- provide links to module documentation and a short example

## Testing
- `dotnet test -v q` *(fails: IsAvailable_WithReadOnlyDirectory_ReturnsFalse)*

------
https://chatgpt.com/codex/tasks/task_e_6857cfc200a48320a1189492a9457ff9