### PR TITLE
Fix order-preserving pipeline merge

### DIFF
--- a/DomsUtils/Services/Pipeline/ChannelPipeline.cs
+++ b/DomsUtils/Services/Pipeline/ChannelPipeline.cs
@@ -153,14 +153,6 @@ public class ChannelPipeline<T> : IAsyncDisposable
             .Select(_ => CreateAndTrackChannel(channelOptions))
             .ToArray();
 
-        // fan-out from single reader
-        if (_currentParallelism == 1 && newFan > 1)
-        {
-            var src = _readers[0];
-            foreach (var ch in nextChans)
-                TrackTask(FanOut(src, ch.Writer, cancellationToken, onError));
-        }
-
         // processors
         for (int i = 0; i < newFan; i++)
         {
@@ -173,8 +165,10 @@ public class ChannelPipeline<T> : IAsyncDisposable
         if (_currentParallelism > 1 && newFan == 1)
         {
             var merged = CreateAndTrackChannel();
-            foreach (var rdr in _readers)
-                TrackTask(FanOut(rdr, merged.Writer, cancellationToken, onError));
+            var tasks = _readers
+                .Select(rdr => FanOut(rdr, merged.Writer, cancellationToken, onError, completeWriter: false))
+                .ToArray();
+            TrackTask(Task.WhenAll(tasks).ContinueWith(_ => merged.Writer.TryComplete()));
             nextChans[0] = merged;
         }
 
@@ -209,10 +203,12 @@ public class ChannelPipeline<T> : IAsyncDisposable
     /// <param name="ct">The cancellation token used to propagate notification of cancellation.</param>
     /// <param name="onError">An optional action invoked when an exception occurs during processing.</param>
     /// <returns>A task representing the asynchronous operation of the fan-out process.</returns>
-    private async Task FanOut(ChannelReader<Envelope<T>> reader,
+    private async Task FanOut(
+        ChannelReader<Envelope<T>> reader,
         ChannelWriter<Envelope<T>> writer,
         CancellationToken ct,
-        Action<Exception>? onError)
+        Action<Exception>? onError,
+        bool completeWriter = true)
     {
         try
         {
@@ -236,7 +232,8 @@ public class ChannelPipeline<T> : IAsyncDisposable
         }
         finally
         {
-            writer.TryComplete();
+            if (completeWriter)
+                writer.TryComplete();
         }
     }
 
@@ -391,8 +388,10 @@ public class ChannelPipeline<T> : IAsyncDisposable
     private ChannelReader<Envelope<T>> MergeReaders(IEnumerable<ChannelReader<Envelope<T>>> srcs)
     {
         var merged = CreateAndTrackChannel();
-        foreach (var r in srcs)
-            TrackTask(FanOut(r, merged.Writer, CancellationToken.None, null));
+        var tasks = srcs
+            .Select(r => FanOut(r, merged.Writer, _completionCts.Token, null, completeWriter: false))
+            .ToArray();
+        TrackTask(Task.WhenAll(tasks).ContinueWith(_ => merged.Writer.TryComplete()));
         return merged.Reader;
     }
 


### PR DESCRIPTION
## Summary
- fix ChannelPipeline merging logic so writers don't close early
- ensure final merge waits for all fan-out tasks

## Testing
- `dotnet test --no-build --verbosity minimal`
- `dotnet test --no-build --verbosity minimal --filter "Build_WithPreserveOrder_ReordersOutput"`

------
https://chatgpt.com/codex/tasks/task_e_6857dd869b088320b16aba8ff551ad01