### PR TITLE
Update wiki publishing secret

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -58,4 +58,4 @@ jobs:
         with:
           path: wiki-pages
         env:
-          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- fix `dotnet-desktop` workflow to use the correct secret name for wiki publishing

## Testing
- `dotnet test --no-build --configuration Release --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6857f2f47aac8320819e4136b4122304