### PR TITLE
Add pipeline block modifiers with tests

### DIFF
--- a/DomsUtils.Tests/Services/Pipeline/BlockModifiersTest.cs
+++ b/DomsUtils.Tests/Services/Pipeline/BlockModifiersTest.cs
@@ -1,0 +1,168 @@
+using DomsUtils.Services.Pipeline;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomsUtils.Tests.Services.Pipeline;
+
+[TestClass]
+public class BlockModifiersTest
+{
+    [TestMethod]
+    public async Task RetryModifier_RetriesUntilSuccess()
+    {
+        int attempts = 0;
+        await using var pipeline = new ChannelPipeline<int>();
+        pipeline.AddBlock(new BlockOptions<int>
+        {
+            AsyncTransform = (v, ct) =>
+            {
+                attempts++;
+                if (attempts < 3) throw new InvalidOperationException("boom");
+                return ValueTask.FromResult(v);
+            },
+            Modifiers = new[] { BlockModifiers.Retry<int>(3) }
+        });
+
+        var reader = pipeline.Build();
+        await pipeline.WriteAsync(1, CancellationToken.None);
+        await pipeline.CompleteAsync();
+
+        var enumerator = reader.ReadAllAsync().GetAsyncEnumerator();
+        Assert.IsTrue(await enumerator.MoveNextAsync());
+        Assert.AreEqual(1, enumerator.Current);
+        await enumerator.DisposeAsync();
+        Assert.AreEqual(3, attempts);
+    }
+
+    [TestMethod]
+    public async Task TimeoutModifier_ThrowsOnLongRunning()
+    {
+        await using var pipeline = new ChannelPipeline<int>();
+        pipeline.AddBlock(new BlockOptions<int>
+        {
+            AsyncTransform = async (v, ct) => { await Task.Delay(200, ct); return v; },
+            Modifiers = new[] { BlockModifiers.Timeout<int>(TimeSpan.FromMilliseconds(50)) }
+        });
+
+        var reader = pipeline.Build();
+        await pipeline.WriteAsync(1, CancellationToken.None);
+        await Assert.ThrowsExceptionAsync<TimeoutException>(async () => await pipeline.CompleteAsync());
+    }
+
+    [TestMethod]
+    public async Task DelayModifier_WaitsBeforeExecution()
+    {
+        await using var pipeline = new ChannelPipeline<int>();
+        pipeline.AddBlock(new BlockOptions<int>
+        {
+            AsyncTransform = (v, ct) => ValueTask.FromResult(v),
+            Modifiers = new[] { BlockModifiers.Delay<int>(TimeSpan.FromMilliseconds(100)) }
+        });
+        var reader = pipeline.Build();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await pipeline.WriteAsync(1, CancellationToken.None);
+        await pipeline.CompleteAsync();
+        await foreach (var _ in reader.ReadAllAsync()) { }
+        Assert.IsTrue(sw.ElapsedMilliseconds >= 100);
+    }
+
+    [TestMethod]
+    public async Task BulkheadModifier_LimitsConcurrency()
+    {
+        await using var pipeline = new ChannelPipeline<int>();
+        int running = 0;
+        int observedMax = 0;
+
+        pipeline.AddBlock(new BlockOptions<int>
+        {
+            Parallelism = 3,
+            AsyncTransform = async (v, ct) =>
+            {
+                Interlocked.Increment(ref running);
+                observedMax = Math.Max(observedMax, Volatile.Read(ref running));
+                await Task.Delay(50, ct);
+                Interlocked.Decrement(ref running);
+                return v;
+            },
+            Modifiers = new[] { BlockModifiers.Bulkhead<int>(1) }
+        });
+
+        var reader = pipeline.Build();
+        await pipeline.WriteAsync(1, CancellationToken.None);
+        await pipeline.WriteAsync(2, CancellationToken.None);
+        await pipeline.WriteAsync(3, CancellationToken.None);
+        await pipeline.CompleteAsync();
+        await foreach (var _ in reader.ReadAllAsync()) { }
+
+        Assert.AreEqual(1, observedMax);
+    }
+
+    [TestMethod]
+    public async Task FallbackModifier_ReplacesErrorValue()
+    {
+        await using var pipeline = new ChannelPipeline<int>();
+        pipeline.AddBlock(new BlockOptions<int>
+        {
+            AsyncTransform = (v, ct) => throw new InvalidOperationException(),
+            Modifiers = new[] { BlockModifiers.Fallback<int>(_ => ValueTask.FromResult(42)) }
+        });
+
+        var reader = pipeline.Build();
+        await pipeline.WriteAsync(1, CancellationToken.None);
+        await pipeline.CompleteAsync();
+        var enumerator = reader.ReadAllAsync().GetAsyncEnumerator();
+        Assert.IsTrue(await enumerator.MoveNextAsync());
+        Assert.AreEqual(42, enumerator.Current);
+        await enumerator.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task ThrottleModifier_EnforcesInterval()
+    {
+        await using var pipeline = new ChannelPipeline<int>();
+        pipeline.AddBlock(new BlockOptions<int>
+        {
+            AsyncTransform = (v, ct) => ValueTask.FromResult(v),
+            Modifiers = new[] { BlockModifiers.Throttle<int>(TimeSpan.FromMilliseconds(50)) }
+        });
+        var reader = pipeline.Build();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await pipeline.WriteAsync(1, CancellationToken.None);
+        await pipeline.WriteAsync(2, CancellationToken.None);
+        await pipeline.CompleteAsync();
+        await foreach (var _ in reader.ReadAllAsync()) { }
+        Assert.IsTrue(sw.ElapsedMilliseconds >= 50);
+    }
+
+    [TestMethod]
+    public async Task Modifiers_CombineSequentially()
+    {
+        await using var pipeline = new ChannelPipeline<int>();
+        int attempts = 0;
+        pipeline.AddBlock(new BlockOptions<int>
+        {
+            AsyncTransform = (v, ct) =>
+            {
+                attempts++;
+                throw new InvalidOperationException();
+            },
+            Modifiers = new BlockModifier<int>[]
+            {
+                BlockModifiers.Retry<int>(2),
+                BlockModifiers.Fallback<int>(_ => ValueTask.FromResult(99))
+            }
+        });
+
+        var reader = pipeline.Build();
+        await pipeline.WriteAsync(1, CancellationToken.None);
+        await pipeline.CompleteAsync();
+
+        var enumerator = reader.ReadAllAsync().GetAsyncEnumerator();
+        Assert.IsTrue(await enumerator.MoveNextAsync());
+        Assert.AreEqual(99, enumerator.Current);
+        await enumerator.DisposeAsync();
+        Assert.AreEqual(3, attempts);
+    }
+}

--- a/DomsUtils/Services/Pipeline/BlockModifiers.cs
+++ b/DomsUtils/Services/Pipeline/BlockModifiers.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomsUtils.Services.Pipeline;
+
+/// <summary>
+/// Collection of helper factories for creating <see cref="BlockModifier{T}"/> delegates.
+/// These modifiers can wrap a block's transformation logic with extra behaviour
+/// such as retry policies, timeouts or simple delays.
+/// </summary>
+public static class BlockModifiers
+{
+    /// <summary>
+    /// Wraps a transformation with retry logic and optional backoff.
+    /// </summary>
+    /// <param name="maxRetries">Maximum number of retries on failure.</param>
+    /// <param name="backoffStrategy">Function that returns the delay before each retry based on the attempt number.</param>
+    /// <typeparam name="T">The item type processed by the block.</typeparam>
+    /// <returns>A modifier that retries the inner block on error.</returns>
+    public static BlockModifier<T> Retry<T>(int maxRetries, Func<int, TimeSpan>? backoffStrategy = null)
+    {
+        if (maxRetries < 0) throw new ArgumentOutOfRangeException(nameof(maxRetries));
+        backoffStrategy ??= attempt => TimeSpan.FromMilliseconds(100 * Math.Pow(2, attempt));
+
+        return next => async (env, ct) =>
+        {
+            int attempt = 0;
+            while (true)
+            {
+                try
+                {
+                    return await next(env, ct).ConfigureAwait(false);
+                }
+                catch (Exception) when (attempt < maxRetries)
+                {
+                    await Task.Delay(backoffStrategy(attempt), ct).ConfigureAwait(false);
+                    attempt++;
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Adds a timeout to a block's execution. Throws <see cref="TimeoutException"/> on expiry.
+    /// </summary>
+    public static BlockModifier<T> Timeout<T>(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        return next => async (env, ct) =>
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(timeout);
+            try
+            {
+                return await next(env, cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cts.IsCancellationRequested && !ct.IsCancellationRequested)
+            {
+                throw new TimeoutException($"Block timed out after {timeout}");
+            }
+        };
+    }
+
+    /// <summary>
+    /// Delays execution of a block by the specified duration.
+    /// </summary>
+    public static BlockModifier<T> Delay<T>(TimeSpan delay)
+    {
+        if (delay < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(delay));
+
+        return next => async (env, ct) =>
+        {
+            if (delay > TimeSpan.Zero)
+                await Task.Delay(delay, ct).ConfigureAwait(false);
+            return await next(env, ct).ConfigureAwait(false);
+        };
+    }
+
+    /// <summary>
+    /// Limits concurrent executions of the wrapped block using a semaphore.
+    /// </summary>
+    /// <param name="maxConcurrency">Maximum number of parallel executions.</param>
+    /// <typeparam name="T">The item type processed by the block.</typeparam>
+    /// <returns>A modifier restricting concurrency.</returns>
+    public static BlockModifier<T> Bulkhead<T>(int maxConcurrency)
+    {
+        if (maxConcurrency <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
+        var sem = new SemaphoreSlim(maxConcurrency);
+
+        return next => async (env, ct) =>
+        {
+            await sem.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                return await next(env, ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                sem.Release();
+            }
+        };
+    }
+
+    /// <summary>
+    /// Substitutes a fallback value if the wrapped block throws an exception.
+    /// </summary>
+    /// <param name="fallbackAsync">Function providing a fallback value based on the error.</param>
+    /// <typeparam name="T">The item type processed by the block.</typeparam>
+    /// <returns>A modifier that returns a fallback value when an error occurs.</returns>
+    public static BlockModifier<T> Fallback<T>(Func<Exception, ValueTask<T>> fallbackAsync)
+    {
+        ArgumentNullException.ThrowIfNull(fallbackAsync);
+
+        return next => async (env, ct) =>
+        {
+            try
+            {
+                return await next(env, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                var val = await fallbackAsync(ex).ConfigureAwait(false);
+                return new Envelope<T>(env.Index, val);
+            }
+        };
+    }
+
+    /// <summary>
+    /// Ensures a minimum interval between consecutive block executions.
+    /// </summary>
+    /// <param name="interval">Interval to wait between executions.</param>
+    /// <typeparam name="T">The item type processed by the block.</typeparam>
+    /// <returns>A modifier that throttles execution rate.</returns>
+    public static BlockModifier<T> Throttle<T>(TimeSpan interval)
+    {
+        if (interval <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(interval));
+        var sem = new SemaphoreSlim(1, 1);
+        var last = DateTime.UtcNow - interval;
+
+        return next => async (env, ct) =>
+        {
+            await sem.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                var wait = last + interval - DateTime.UtcNow;
+                if (wait > TimeSpan.Zero)
+                    await Task.Delay(wait, ct).ConfigureAwait(false);
+                last = DateTime.UtcNow;
+            }
+            finally
+            {
+                sem.Release();
+            }
+
+            return await next(env, ct).ConfigureAwait(false);
+        };
+    }
+}

--- a/DomsUtils/Services/Pipeline/README.md
+++ b/DomsUtils/Services/Pipeline/README.md
@@ -9,6 +9,20 @@ A composable channel-based pipeline for asynchronous data processing.
 - `BlockModifier<T>` – delegate to wrap transformations with extra behavior.
 - `Envelope<T>` – wrapper that tracks item ordering.
 
+## Built-In Modifiers
+
+`BlockModifiers` provides helpers for common scenarios:
+
+- **Retry** – retry a block with optional backoff.
+- **Timeout** – cancel a block if it exceeds a time limit.
+- **Delay** – introduce a fixed delay before executing a block.
+- **Bulkhead** – limit the number of concurrent executions.
+- **Fallback** – return a fallback value when a block fails.
+- **Throttle** – enforce a minimum delay between executions.
+
+These can be combined by adding them to `BlockOptions.Modifiers`.
+Modifiers are applied in the order they appear in the array.
+
 ## Example
 
 ```csharp
@@ -18,10 +32,14 @@ var pipeline = new ChannelPipeline<int>(preserveOrder: true)
     .AddBlock(new BlockOptions<int>
     {
         AsyncTransform = async (v, ct) => v * 2,
-        Parallelism = 2
+        Parallelism = 2,
+        Modifiers = new BlockModifier<int>[]
+        {
+            BlockModifiers.Delay<int>(TimeSpan.FromMilliseconds(100)),
+            BlockModifiers.Retry<int>(2)
+        }
     });
 
 await pipeline.WriteAsync(5, CancellationToken.None);
 await pipeline.DisposeAsync();
 ```
-

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A growing collection of general‑purpose utilities for .NET projects. The libra
 - **[BiMap](DomsUtils/DataStructures/BiMap/README.md)** – bidirectional dictionary implementation.
 - **[CircularBuffer](DomsUtils/DataStructures/CircularBuffer/Base/README.md)** – fixed size queue with constant time operations.
 - **[Caching](DomsUtils/Services/Caching/README.md)** – memory, file and S3 based caches with hybrid compositions.
-- **[Pipeline](DomsUtils/Services/Pipeline/README.md)** – composable channel pipeline for async workloads.
+- **[Pipeline](DomsUtils/Services/Pipeline/README.md)** – composable channel pipeline for async workloads with built‑in block modifiers.
 - **[Async Utils](DomsUtils/Tooling/Async/README.md)** – helpers for running delegates with retries and timeouts.
 - **[Enumerable Extensions](DomsUtils/Tooling/ExtensionMethods/README.md)** – LINQ style helpers for `IEnumerable<T>`.
 


### PR DESCRIPTION
## Summary
- add new modifiers: `Bulkhead`, `Fallback` and `Throttle`
- document all available block modifiers and how to combine them
- test bulkhead, fallback, throttle and modifier combination

## Testing
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6858440aa1188320bf625ddc0325785e