### PR TITLE
Add branching capability to pipeline

### DIFF
--- a/DomsUtils.Tests/Services/Pipeline/BranchingExtensionsTest.cs
+++ b/DomsUtils.Tests/Services/Pipeline/BranchingExtensionsTest.cs
@@ -1,0 +1,59 @@
+using DomsUtils.Services.Pipeline;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomsUtils.Tests.Services.Pipeline;
+
+[TestClass]
+public class BranchingExtensionsTest
+{
+    [TestMethod]
+    public async Task BranchIf_SelectsCorrectBranch()
+    {
+        await using var pipeline = new ChannelPipeline<int>();
+        pipeline.BranchIf(
+            v => v % 2 == 0,
+            new BlockOptions<int> { AsyncTransform = (v, ct) => ValueTask.FromResult(v * 2) },
+            new BlockOptions<int> { AsyncTransform = (v, ct) => ValueTask.FromResult(v + 1) }
+        );
+
+        var reader = pipeline.Build();
+
+        await pipeline.WriteAsync(1, CancellationToken.None);
+        await pipeline.WriteAsync(2, CancellationToken.None);
+        await pipeline.WriteAsync(3, CancellationToken.None);
+        await pipeline.WriteAsync(4, CancellationToken.None);
+        await pipeline.CompleteAsync();
+
+        var results = new List<int>();
+        await foreach (var item in reader.ReadAllAsync())
+            results.Add(item);
+
+        CollectionAssert.AreEqual(new[] { 2, 4, 4, 8 }, results);
+    }
+
+    [TestMethod]
+    public async Task BranchIf_NoFalseBranch_PassThrough()
+    {
+        await using var pipeline = new ChannelPipeline<int>();
+        pipeline.BranchIf(
+            v => v > 2,
+            new BlockOptions<int> { AsyncTransform = (v, ct) => ValueTask.FromResult(v * 10) }
+        );
+
+        var reader = pipeline.Build();
+
+        await pipeline.WriteAsync(1, CancellationToken.None);
+        await pipeline.WriteAsync(2, CancellationToken.None);
+        await pipeline.WriteAsync(3, CancellationToken.None);
+        await pipeline.CompleteAsync();
+
+        var results = new List<int>();
+        await foreach (var item in reader.ReadAllAsync())
+            results.Add(item);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 30 }, results);
+    }
+}

--- a/DomsUtils/Services/Pipeline/Core/BranchingExtensions.cs
+++ b/DomsUtils/Services/Pipeline/Core/BranchingExtensions.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomsUtils.Services.Pipeline;
+
+/// <summary>
+/// Extension methods providing conditional branching for <see cref="ChannelPipeline{T}"/>.
+/// </summary>
+public static class BranchingExtensions
+{
+    /// <summary>
+    /// Executes different blocks based on a boolean condition.
+    /// </summary>
+    /// <typeparam name="T">Type of data processed by the pipeline.</typeparam>
+    /// <param name="pipeline">The pipeline to add the branching block to.</param>
+    /// <param name="condition">Predicate used to choose the branch.</param>
+    /// <param name="trueBlock">Block executed when the condition is true.</param>
+    /// <param name="falseBlock">Optional block executed when the condition is false. When null the item is passed through.</param>
+    /// <returns>The pipeline instance for chaining.</returns>
+    public static ChannelPipeline<T> BranchIf<T>(
+        this ChannelPipeline<T> pipeline,
+        Func<T, bool> condition,
+        BlockOptions<T> trueBlock,
+        BlockOptions<T>? falseBlock = null)
+    {
+        if (pipeline == null) throw new ArgumentNullException(nameof(pipeline));
+        if (condition == null) throw new ArgumentNullException(nameof(condition));
+        if (trueBlock == null) throw new ArgumentNullException(nameof(trueBlock));
+
+        BlockModifier<T>[]? CombineModifiers(IReadOnlyList<BlockModifier<T>>? first, IReadOnlyList<BlockModifier<T>>? second)
+        {
+            if (first == null && second == null) return null;
+            var list = new List<BlockModifier<T>>();
+            if (first != null) list.AddRange(first);
+            if (second != null) list.AddRange(second);
+            return list.ToArray();
+        }
+
+        var branchFlag = new AsyncLocal<bool>();
+
+        var options = new BlockOptions<T>
+        {
+            Parallelism = Math.Max(trueBlock.Parallelism, falseBlock?.Parallelism ?? 1),
+            ChannelOptions = trueBlock.ChannelOptions ?? falseBlock?.ChannelOptions,
+            CancellationToken = trueBlock.CancellationToken != CancellationToken.None
+                ? trueBlock.CancellationToken
+                : (falseBlock?.CancellationToken ?? CancellationToken.None),
+            Modifiers = CombineModifiers(trueBlock.Modifiers, falseBlock?.Modifiers),
+            OnError = ex =>
+            {
+                var handler = branchFlag.Value ? trueBlock.OnError : falseBlock?.OnError;
+                handler?.Invoke(ex);
+            },
+            AsyncTransform = async (item, ct) =>
+            {
+                branchFlag.Value = condition(item);
+                if (branchFlag.Value)
+                    return await trueBlock.AsyncTransform(item, ct);
+                else if (falseBlock != null)
+                    return await falseBlock.AsyncTransform(item, ct);
+                return item;
+            }
+        };
+
+        return pipeline.AddBlock(options);
+    }
+}


### PR DESCRIPTION
## Summary
- add `BranchIf` extension to conditionally execute different blocks
- test branching support in pipeline

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685965668d3c8320808c9a68efd39712